### PR TITLE
FIX - Compilation issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,13 @@
 	<groupId>FileFandom</groupId>
 	<artifactId>FileFandom</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.source.version>1.8</java.source.version>
+        <java.target.version>1.8</java.target.version>
+        <jhove.version>1.22.1</jhove.version>
+    </properties>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>
@@ -13,13 +20,12 @@
 				<version>3.8.0</version>
 				<configuration>
 					<release>12</release>
-				</configuration>
+                    <source>${java.source.version}</source>
+                    <target>${java.target.version}</target>
+                </configuration>
 			</plugin>
 		</plugins>
 	</build>
-	<properties>
-		<jhove.version>1.22.1</jhove.version>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/SimpleTools/GetMD5.java
+++ b/src/SimpleTools/GetMD5.java
@@ -1,12 +1,11 @@
 package SimpleTools;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 
 import javax.swing.JOptionPane;
-
-import thredds.filesystem.FileSystemProto.File;
 
 public class GetMD5 {
 
@@ -16,13 +15,13 @@ public class GetMD5 {
 				JOptionPane.QUESTION_MESSAGE);
 		String folder = Utilities.BrowserDialogs.chooseFolder();
 
-		ArrayList<File> files = Utilities.ListsFiles.getPaths(new File(), new ArrayList<File>());
+		ArrayList<File> files = Utilities.ListsFiles.getPaths(new File(folder), new ArrayList<File>());
 
-		for (int i = 0; i < files.size(); i++) {
+		for (File file : files) {
 
-			String md5checksum = Utilities.GetMD5checksum(files.get(i));
+			String md5checksum = Utilities.GetMD5checksum.getChecksum(file);
 						System.out.println(md5checksum);
 
 		}
-
+	}
 }

--- a/src/iTextrepairPDF/repairStructurePdf.java
+++ b/src/iTextrepairPDF/repairStructurePdf.java
@@ -63,7 +63,6 @@ public class repairStructurePdf {
 	 * 
 	 */
 
-	@SuppressWarnings("rawtypes")
 	static void repairWithItext(PdfReader reader, File filename) throws DocumentException, IOException {
 
 		Map<String, String> info = reader.getInfo();


### PR DESCRIPTION
- added standard Maven properties for encoding;
- tied to Java version 8;
- use native Java `java.io.File` class rather than `thredds.filesystem.FileSystemProto.File`;
- use modern loop iteration rather than counters; and
- fixed broken calls to `Utilities.GetMD5checksum`.