### PR TITLE
FIX - JHOVE classes in a fat JAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dependency-reduced-pom.xml
 .classpath
 .project
 .settings

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,44 @@
                     <target>${java.target.version}</target>
                 </configuration>
 			</plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-shade-plugin</artifactId>
+              <version>3.2.1</version>
+              <configuration>
+                <createDependencyReducedPom>true</createDependencyReducedPom>
+                <filters>
+                  <filter>
+                    <artifact>*:*</artifact>
+                    <excludes>
+                      <exclude>META-INF/*.SF</exclude>
+                      <exclude>META-INF/*.DSA</exclude>
+                      <exclude>META-INF/*.RSA</exclude>
+                    </excludes>
+                  </filter>
+                </filters>
+              </configuration>
+              <executions>
+                <execution>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>shade</goal>
+                  </goals>
+                  <configuration>
+                    <transformers>
+                      <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                      <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                      </transformer>
+                    </transformers>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
 		</plugins>
 	</build>
+
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,7 @@
 	<artifactId>FileFandom</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
         <java.source.version>1.8</java.source.version>
         <java.target.version>1.8</java.target.version>
         <jhove.version>1.22.1</jhove.version>
@@ -19,7 +18,6 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-					<release>12</release>
                     <source>${java.source.version}</source>
                     <target>${java.target.version}</target>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,13 @@
 	<groupId>FileFandom</groupId>
 	<artifactId>FileFandom</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.source.version>1.8</java.source.version>
+        <java.target.version>1.8</java.target.version>
+        <jhove.version>1.22.1</jhove.version>
+    </properties>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>
@@ -13,13 +20,12 @@
 				<version>3.8.0</version>
 				<configuration>
 					<release>12</release>
-				</configuration>
+                    <source>${java.source.version}</source>
+                    <target>${java.target.version}</target>
+                </configuration>
 			</plugin>
 		</plugins>
 	</build>
-	<properties>
-		<jhove.version>1.22.1</jhove.version>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/JhoveValidations/ValidatePdf.java
+++ b/src/JhoveValidations/ValidatePdf.java
@@ -84,9 +84,9 @@ public class ValidatePdf {
 				writer.println("<JhoveFindings>");
 
 				// To handle one file after the other
-				for (int i = 0; i < files.size(); i++) {
+				for (File file : files) {
 					boolean encrypted = false;
-					if (Utilities.GenericFileAnalysis.testFileHeaderPdf(files.get(i)) == true) { // tests
+					if (Utilities.GenericFileAnalysis.testFileHeaderPdf(file) == true) { // tests
 																									// only
 																									// PDF
 																									// with
@@ -95,12 +95,12 @@ public class ValidatePdf {
 						writer.println("<item>");
 
 						String substitute = Utilities.FileStringUtilities
-								.getFileNameFromString(files.get(i).toString());
+								.getFileNameFromString(file.toString());
 						substitute = Utilities.ReduceIllegalCharacters.reduceXmlEscapors(substitute);
 						writer.println("<filename>" + substitute + "</filename>");
 
 						PDDocument pd = new PDDocument();
-						pd = PDDocument.load(files.get(i));
+						pd = PDDocument.load(file);
 
 						if (pd.isEncrypted()) {
 							encrypted = true;
@@ -122,7 +122,7 @@ public class ValidatePdf {
 						addSomeMetadata(info);
 						pd.close();
 
-						jb.process(app, module, handler, files.get(i).toString());
+						jb.process(app, module, handler, file.toString());
 						writer.println("</item>");
 					}
 

--- a/src/SimpleTools/GetMD5.java
+++ b/src/SimpleTools/GetMD5.java
@@ -1,12 +1,11 @@
 package SimpleTools;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 
 import javax.swing.JOptionPane;
-
-import thredds.filesystem.FileSystemProto.File;
 
 public class GetMD5 {
 
@@ -16,13 +15,13 @@ public class GetMD5 {
 				JOptionPane.QUESTION_MESSAGE);
 		String folder = Utilities.BrowserDialogs.chooseFolder();
 
-		ArrayList<File> files = Utilities.ListsFiles.getPaths(new File(), new ArrayList<File>());
+		ArrayList<File> files = Utilities.ListsFiles.getPaths(new File(folder), new ArrayList<File>());
 
-		for (int i = 0; i < files.size(); i++) {
+		for (File file : files) {
 
-			String md5checksum = Utilities.GetMD5checksum(files.get(i));
+			String md5checksum = Utilities.GetMD5checksum.getChecksum(file);
 						System.out.println(md5checksum);
 
 		}
-
+	}
 }

--- a/src/iTextrepairPDF/repairStructurePdf.java
+++ b/src/iTextrepairPDF/repairStructurePdf.java
@@ -63,7 +63,6 @@ public class repairStructurePdf {
 	 * 
 	 */
 
-	@SuppressWarnings("rawtypes")
 	static void repairWithItext(PdfReader reader, File filename) throws DocumentException, IOException {
 
 		Map<String, String> info = reader.getInfo();


### PR DESCRIPTION
- using Maven shade pluin:
  * uses a "fat JAR" for Maven build;
  * all JHOVE classes in new JAR;
- changed source encoding to Latin as used by Windows for German characters; and
- fixed another old style loop iteration.
